### PR TITLE
Error protocol

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ language: objective-c
 # xcode_scheme: SwiftyJSONAPI
 osx_image: xcode8.2
 script:
-    - xcodebuild clean build test -project SwiftyJSONAPI.xcodeproj -scheme SwiftyJSONAPI -destination 'platform=iOS Simulator,id=22FA2149-1241-469C-BF6D-462D3837DB72' #iPhone 7
+    - xcodebuild clean build test -project SwiftyJSONAPI.xcodeproj -scheme SwiftyJSONAPI -destination 'platform=iOS Simulator,id=86B2CA7C-0247-4257-BFEA-8035084AF2CF' #iPhone 7
 

--- a/SwiftyJSONAPI.podspec
+++ b/SwiftyJSONAPI.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "SwiftyJSONAPI"
-  s.version      = "0.0.15"
+  s.version      = "0.0.16"
   s.summary      = "JSONAPI document representation and serializing in Swift."
 
   s.homepage     = "https://github.com/thomassnielsen/SwiftyJSONAPI"

--- a/SwiftyJSONAPI/JSONAPIError.swift
+++ b/SwiftyJSONAPI/JSONAPIError.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 
-open class JSONAPIError: JSONPrinter {
+open class JSONAPIError: JSONPrinter, Error {
 
     open var id = ""
     open var links: [String:URL] = [:]
@@ -83,11 +83,6 @@ open class JSONAPIError: JSONPrinter {
         }
         
         return dict
-    }
-    
-    //TODO: fill it with the correct attributes
-    open func toNSError() -> NSError {
-        return NSError(domain: "SwiftyJSONAPI", code: 99, userInfo: nil)
     }
 
 


### PR DESCRIPTION
Removing the toNSError method, making JSONAPIError act as a Throwable error.