### PR TITLE
Performance improvements when loading included resources

### DIFF
--- a/SwiftyJSONAPI/JSONAPIResource.swift
+++ b/SwiftyJSONAPI/JSONAPIResource.swift
@@ -92,23 +92,22 @@ public class JSONAPIResource: JSONPrinter {
         return attributes[key]
     }
     
-    public func loadIncludedResources(){
-        guard let includes = parent?.included else { return }
+    func loadResources(withIncludedResources includedResources: ResourcesByTypeAndId) {
         
         for relationship in self.relationships {
             
             for resource in relationship.resources {
                 
-                if let includedResource = includes.first(where: {$0.id == resource.id && $0.type == resource.type }) {
-                    
-                    resource.attributes = includedResource.attributes
-                    resource.relationships = includedResource.relationships
-                    if !resource.relationships.isEmpty {
-                        resource.parent = self.parent
-                        resource.loadIncludedResources()
-                    }
-                    resource.loaded = .Loaded
+                guard let includedResource = includedResources[resource] else { continue }
+                
+                resource.attributes    = includedResource.attributes
+                resource.relationships = includedResource.relationships
+                
+                if !resource.relationships.isEmpty {
+                    resource.parent = self.parent
+                    resource.loadResources(withIncludedResources: includedResources)
                 }
+                resource.loaded = .Loaded
             }
         }
     }

--- a/SwiftyJSONAPITests/JSONAPIDocumentTests.swift
+++ b/SwiftyJSONAPITests/JSONAPIDocumentTests.swift
@@ -72,6 +72,33 @@ class JSONAPIDocumentTests: XCTestCase {
         
     }
     
+    func testResourcesLoadedFromInclude () {
+        let document = try! JSONAPIDocument(self.testData)
+        var authorAttributesCount   = 0
+        var commentsAttributesCount = 0
+        
+        document.loadIncludedResources()
+        
+        guard let postResource = document.data.first else {
+            XCTFail("Could not find resource of type Post"); return
+        }
+        
+        postResource.relationships.forEach { relationship in
+            switch relationship.type {
+            case "author":
+                authorAttributesCount = relationship.resources.first?.attributes.count ?? 0
+            case "comments":
+                commentsAttributesCount = relationship.resources.first?.attributes.count ?? 0
+            default:
+                // For now we are only handling these 2 cases
+                break
+            }
+        }
+        
+        XCTAssertTrue(authorAttributesCount == 3,"Author resource should contain 3 attributes")
+        XCTAssertTrue(commentsAttributesCount == 1,"Comment resource should contain 1 attribute")
+    }
+    
 //
     func testPerformanceExample() {
         // This is an example of a performance test case.


### PR DESCRIPTION
# **Changes proposed in this pull request:**
Improve performance when loading the resources from the include section.

**Previous Solution**
Previously to map the resources received on the include section we would recursively go through all the relationships present in the data section and search in all the included resources for the first resource that would match the id and type.

**Improved Solution**
To improve this search for a resource I'm creating first a dictionary that groups the resources by type and then by Id, that dictionary will be used to return the resource needed and will have a complexity O(1).
In this approach we need to take into account the creation of the dictionary which takes a very insignificant amount of time and has a complexity of O(n), since it only enumerates through the included resources, but could increase in some milliseconds when the payload is very small.

**Measurements**
With the changes proposed I can see a huge improvement when the JSONAPIDocument is composed by a considerable number of relationships (thousands), where the processing time decreased from 20 seconds to 0.8 seconds.