### PR TITLE
Fixing bug in latest version

### DIFF
--- a/SwiftyJSONAPI/JSONAPIResource.swift
+++ b/SwiftyJSONAPI/JSONAPIResource.swift
@@ -96,31 +96,30 @@ public class JSONAPIResource: JSONPrinter {
     }
     
     func loadResources(withIncludedResources includedResources: ResourcesByTypeAndId) {
-        
-        func _loadResources(withIncludedResources includedResources: ResourcesByTypeAndId, cachedResources: inout CachedResources) {
-            for relationship in self.relationships {
-                
-                for resource in relationship.resources {
-                    
-                    guard let includedResource = includedResources[resource] else { continue }
-                    
-                    resource.attributes    = includedResource.attributes
-                    resource.relationships = includedResource.relationships
-                    
-                    
-                    if !resource.relationships.isEmpty, resource.cacheIfNeeded(&cachedResources) {
-                        
-                        resource.parent = self.parent
-                        _loadResources(withIncludedResources: includedResources, cachedResources: &cachedResources)
-                    }
-                    
-                    resource.loaded = .Loaded
-                }
-            }
-        }
-        
         var cachedResources = CachedResources()
         _loadResources(withIncludedResources: includedResources, cachedResources: &cachedResources)
+    }
+    
+    fileprivate  func _loadResources(withIncludedResources includedResources: ResourcesByTypeAndId, cachedResources: inout CachedResources) {
+        for relationship in self.relationships {
+            
+            for resource in relationship.resources {
+                
+                guard let includedResource = includedResources[resource] else { continue }
+                
+                resource.attributes    = includedResource.attributes
+                resource.relationships = includedResource.relationships
+                
+                
+                if !resource.relationships.isEmpty, resource.cacheIfNeeded(&cachedResources) {
+                    
+                    resource.parent = self.parent
+                    resource._loadResources(withIncludedResources: includedResources, cachedResources: &cachedResources)
+                }
+                
+                resource.loaded = .Loaded
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fixing a bug we found in latest SwiftyJSONAPI version - basically a  function was called recursively that was local and should have been a member function on the resource object.

https://github.com/thomassnielsen/SwiftyJSONAPI/pull/13/files#diff-17206e60ee1273002aceab1589875e69R114 
vs
 https://github.com/thomassnielsen/SwiftyJSONAPI/blob/ac5db0097359dd753a51fff97aeff656c3e198d2/SwiftyJSONAPI/JSONAPIResource.swift#L108

Basically the fix here is to change `_loadResources` into a member function and not just a location function and call that on `JSONAPIResource` 

The diff looks big but its really isnt that crazy - its just moving a function into `fileprivate` scope on `JSONAPIResource` and calling that on the `resource` in the loop inside that very function.