### PR TITLE
Add Swift Package Manager Support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,34 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "SwiftyJSONAPI",
+    platforms: [.macOS(.v10_10),
+                .iOS(.v9)],
+    products: [
+        .library(
+            name: "SwiftyJSONAPI",
+            targets: ["SwiftyJSONAPI"]),
+    ],
+    targets: [
+        .target(
+            name: "SwiftyJSONAPI",
+            dependencies: [],
+            path: "SwiftyJSONAPI",
+            exclude: ["Info.plist"]),
+        .testTarget(
+            name: "SwiftyJSONAPITests",
+            dependencies: ["SwiftyJSONAPI"],
+            path: "SwiftyJSONAPITests",
+            exclude: ["Info.plist"],
+            resources: [
+                .copy("example-bidirectional-relationship.json"),
+                .copy("example-document-1.json"),
+                .copy("example-error.json")
+            ]),
+
+    ],
+    swiftLanguageVersions: [.v5]
+)

--- a/SwiftyJSONAPITests/JSONAPIDocumentTests.swift
+++ b/SwiftyJSONAPITests/JSONAPIDocumentTests.swift
@@ -9,80 +9,89 @@
 import XCTest
 @testable import SwiftyJSONAPI
 
-class JSONAPIDocumentTests: XCTestCase {
+final class JSONAPIDocumentTests: XCTestCase {
 
-    var testData: Data!
-    
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-        if let file = Bundle(for: JSONAPIDocumentTests.self).path(forResource: "example-document-1", ofType: "json") {
-            self.testData = try? Data(contentsOf: URL(fileURLWithPath: file))
-        } else {
-            XCTFail("Could not find test file")
+    private func fetchDocument(for resource: String) -> JSONAPIDocument? {
+        #if SWIFT_PACKAGE
+        guard let url = Bundle.module.url(forResource: resource, withExtension: nil) else {
+            XCTFail()
+            return nil
         }
-    }
-    
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
+        #else
+        guard let file = Bundle(for: JSONAPIDocumentTests.self).path(forResource: resource, ofType: nil) else {
+            XCTFail()
+            return nil
+        }
+        let url = URL(fileURLWithPath: file)
+        #endif
+        let testData = try! Data(contentsOf: url)
+        return try? JSONAPIDocument(testData)
     }
 
     func testImportingDocument() {
-        let document = try! JSONAPIDocument(self.testData)
-        
+        guard let document = fetchDocument(for: "example-document-1.json") else {
+            XCTFail()
+            return
+        }
+
         XCTAssert(document.data.count == 1, "Expected number of data elements to be 1, was \(document.data.count)")
         XCTAssert(document.included.count == 3, "Expected number of included documents to be 2, was \(document.included.count)")
         XCTAssert(document.links.count == 3, "Expected number of links to be 3, was \(document.links.count)")
-        
+
         XCTAssertNotNil(document.url, "Expected document to find its own URL from the provided links")
     }
-    
+
     func testRelationships() {
-        let document = try! JSONAPIDocument(self.testData)
+        guard let document = fetchDocument(for: "example-document-1.json") else {
+            XCTFail()
+            return
+        }
         let resource = document.data.first!
-        
+
         XCTAssertNotNil(resource.url, "Resources should have an URL")
         XCTAssert(resource.relationships.count == 2, "Expected number of relationships to be 2, was \(resource.relationships.count)")
     }
-    
+
     func testErrors() {
-        
-        if let errorFile = Bundle(for: JSONAPIDocumentTests.self).path(forResource: "example-error", ofType: "json") {
-            self.testData = try? Data(contentsOf: URL(fileURLWithPath: errorFile))
-        } else {
-            XCTFail("Could not find error test file")
+
+        guard let document = fetchDocument(for: "example-error.json") else {
+            XCTFail()
+            return
         }
-        
-        let document = try! JSONAPIDocument(self.testData)
         let error = document.errors.first!
-        
+
         XCTAssertNotNil(error.id, "Errors should have an id")
         XCTAssertEqual(error.status,"422", "Expected error code to be 422")
-    
+
     }
-    
+
     func testMeta() {
-        let document = try! JSONAPIDocument(self.testData)
+        guard let document = fetchDocument(for: "example-document-1.json") else {
+            XCTFail()
+            return
+        }
         let meta = document.meta!
         let keys = [String](meta.keys)
-    
-        XCTAssertNotNil(meta, "document should have meta information")        
+
+        XCTAssertNotNil(meta, "document should have meta information")
         XCTAssertTrue(keys.contains("authors"),"meta should contain a authors key")
-        
+
     }
-    
+
     func testResourcesLoadedFromInclude() {
-        let document = try! JSONAPIDocument(self.testData)
+        guard let document = fetchDocument(for: "example-document-1.json") else {
+            XCTFail()
+            return
+        }
         var authorAttributesCount   = 0
         var commentsAttributesCount = 0
-        
+
         document.loadIncludedResources()
-        
+
         guard let postResource = document.data.first else {
             XCTFail("Could not find resource of type Post"); return
         }
-        
+
         postResource.relationships.forEach { relationship in
             switch relationship.type {
             case "author":
@@ -94,30 +103,28 @@ class JSONAPIDocumentTests: XCTestCase {
                 break
             }
         }
-        
+
         XCTAssertTrue(authorAttributesCount == 3,"Author resource should contain 3 attributes")
         XCTAssertTrue(commentsAttributesCount == 1,"Comment resource should contain 1 attribute")
     }
-    
-    func testbidirectionalRelationship() {
-        if let bidirectionalFile = Bundle(for: JSONAPIDocumentTests.self).path(forResource: "example-bidirectional-relationship", ofType: "json") {
-            self.testData = try? Data(contentsOf: URL(fileURLWithPath: bidirectionalFile))
-        } else {
-            XCTFail("Could not find error test file")
+
+    func testBidirectionalRelationship() {
+
+        guard let document = fetchDocument(for: "example-bidirectional-relationship.json") else {
+            XCTFail()
+            return
         }
-        
         var userHasAdressRelationship = false
         var addressHasUserRelationship = false
-        
-        let document = try! JSONAPIDocument(self.testData)
+
         document.loadIncludedResources()
-        
+
         let resource = document.data.first
-        
+
         resource?.relationships.forEach { relationship in
             switch relationship.type {
             case "user":
-               userHasAdressRelationship = relationship.hasRelationship(toType: "address")
+                userHasAdressRelationship = relationship.hasRelationship(toType: "address")
             case "address":
                 addressHasUserRelationship = relationship.hasRelationship(toType: "user")
             default:
@@ -125,19 +132,10 @@ class JSONAPIDocumentTests: XCTestCase {
                 break
             }
         }
-        
+
         XCTAssertTrue(userHasAdressRelationship, "Expected user to have a relationship to addess")
         XCTAssertTrue(addressHasUserRelationship, "Expected address to have a relationship to a user")
     }
-    
-//
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measure {
-            _ = try! JSONAPIDocument(self.testData)
-        }
-    }
-
 }
 
 private extension JSONAPIRelationship {


### PR DESCRIPTION
Adding support for Swift Package Manager. The tests setup had to be overhauled some to account for running them via the `.xcodeproj` or as a package when accessing the files from the Bundle. This can be tweaked, but I felt this was a good approach. 

Let me know your thoughts!